### PR TITLE
Remove void from method declarations

### DIFF
--- a/src/gui/Board.hpp
+++ b/src/gui/Board.hpp
@@ -18,7 +18,6 @@ namespace gui {
     QRectF boundingRect() const;
 
     void changeCoordinates(float& x, float& y, float xDiff, float yDiff, int numberHardToName);
-
   };
 }
 

--- a/src/gui/BoardField.cpp
+++ b/src/gui/BoardField.cpp
@@ -5,7 +5,7 @@ BoardField::BoardField(Field* field, float radius, QGraphicsItem* parent)
 {
 }
 
-Field* BoardField::getField(void) {
+Field * BoardField::getField() {
   return field;
 }
 

--- a/src/gui/BoardField.hpp
+++ b/src/gui/BoardField.hpp
@@ -12,7 +12,7 @@ class BoardField : public Hexagon
 public:
   BoardField(Field* field, float radius = 50, QGraphicsItem *parent = 0);
 
-  Field* getField(void);
+  Field *getField();
 
 signals:
   void fieldClicked(BoardField*);

--- a/src/gui/MainWindowSample.cpp
+++ b/src/gui/MainWindowSample.cpp
@@ -15,7 +15,7 @@ MainWindowSample::MainWindowSample(Controller* modelController, QWidget *parent)
   QGraphicsScene * scene = new QGraphicsScene(this);
   scene->setBackgroundBrush(Qt::darkGray);
 
-  Field * middleField = modelController -> getModelBoard() -> getMiddleField();
+  Field * middleField = modelController->getModelBoard()->getMiddleField();
 
   gui::Board * board = new gui::Board(controller, middleField);
   board -> setPos(0, 0);

--- a/src/gui/SideField.cpp
+++ b/src/gui/SideField.cpp
@@ -5,11 +5,11 @@ SideField::SideField(int player, int whichToken, float radius, QGraphicsItem* pa
 {
 }
 
-int SideField::getPlayer(void) {
+int SideField::getPlayer() {
   return player;
 }
 
-int SideField::getWhichToken(void) {
+int SideField::getWhichToken() {
   return whichToken;
 }
 

--- a/src/gui/SideField.hpp
+++ b/src/gui/SideField.hpp
@@ -11,8 +11,8 @@ class SideField : public Hexagon
 public:
   SideField(int player, int whichToken, float radius = 50, QGraphicsItem *parent = 0);
 
-  int getPlayer(void);
-  int getWhichToken(void);
+  int getPlayer();
+  int getWhichToken();
 
 signals:
   void fieldClicked(SideField*);

--- a/src/gui/ViewController.cpp
+++ b/src/gui/ViewController.cpp
@@ -6,11 +6,11 @@ ViewController::ViewController(Controller* modelController, QObject *parent) : Q
 }
 
 void ViewController::fieldClicked(BoardField* field) {
-  qDebug() << "Field on board Clicked. Pointer: " << field -> getField();
+  qDebug() << "Field on board Clicked. Pointer: " << field->getField();
   field -> setImageAndRotation("armies/moloch/headquarters.png", (1 % 6 )*60);
 }
 
 void ViewController::handFieldClicked(SideField* field) {
-  qDebug() << "Hand field number: " << field -> getWhichToken() << " of player: " <<  field -> getPlayer() << " Clicked.";
+  qDebug() << "Hand field number: " << field->getWhichToken() << " of player: " << field->getPlayer() << " Clicked.";
   field -> setImageAndRotation("armies/moloch/headquarters.png", (1 % 6 )*60);
 }

--- a/src/logic/Attribute.cpp
+++ b/src/logic/Attribute.cpp
@@ -5,11 +5,11 @@ Attribute::Attribute(std::string name, int baseValue)
   this->currentValue = baseValue;
 }
 
-std::string Attribute::getName(void) {
+std::string Attribute::getName() {
   return name;
 }
 
-int Attribute::getValue(void) {
+int Attribute::getValue() {
   return currentValue;
 }
 
@@ -25,7 +25,7 @@ void Attribute::upgradeTo(int newValue) {
   currentValue = newValue;
 }
 
-void Attribute::resetValue(void) {
+void Attribute::resetValue() {
   currentValue = baseValue;
 }
 

--- a/src/logic/Attribute.hpp
+++ b/src/logic/Attribute.hpp
@@ -11,18 +11,17 @@ public:
   void upgradeBy(int amount = 1);
   void downgradeBy(int amount = 1);
   void upgradeTo(int newValue);
-  void resetValue(void);
   void downgradeTo(int newValue);
+  void resetValue();
 
   //getters
-  std::string getName(void);
-  int getValue(void);
+  std::string getName();
+  int getValue();
 
 private:
   std::string name;
   int baseValue;
   int currentValue;
-
 };
 
 #endif //ATTRIBUTE_HPP

--- a/src/logic/Attributes.cpp
+++ b/src/logic/Attributes.cpp
@@ -1,9 +1,6 @@
 #include "Attributes.hpp"
 
-Attributes::Attributes(void) {
-}
-
-Attributes::~Attributes(void) {
+Attributes::~Attributes() {
   for (auto it = attributes.begin(); it != attributes.end(); it++) {
     delete it->second;
   }
@@ -34,6 +31,6 @@ void Attributes::removeAttribute(AttributeName name) {
   }
 }
 
-bool Attributes::empty(void) {
+bool Attributes::empty() {
   return attributes.empty();
 }

--- a/src/logic/Attributes.hpp
+++ b/src/logic/Attributes.hpp
@@ -7,16 +7,15 @@
 
 class Attributes {
 public:
-  Attributes(void);
-  ~Attributes(void);
+  ~Attributes();
 
   //getters
   Attribute* getAttribute(AttributeName name);
-  int getSize(void);
+  int getSize();
 
   void addAttribute(AttributeName name, Attribute* attribute);
   void removeAttribute(AttributeName name);
-  bool empty(void);
+  bool empty();
 
 private:
   std::map < AttributeName, Attribute*> attributes;

--- a/src/logic/Board.hpp
+++ b/src/logic/Board.hpp
@@ -7,14 +7,14 @@
 class Board
 {
 public:
-  Board(void);
-  ~Board(void);
-  Field* getMiddleField(void);
+  Board();
+  ~Board();
+  Field *getMiddleField();
 
 private:
-  void createMiddleRing(void);
+  void createMiddleRing();
   void linkMiddleRing();
-  void createOutsideRing(void);
+  void createOutsideRing();
   void linkOutsideRing();
 
   std::vector <Field* > fields;

--- a/src/logic/BoardToken.cpp
+++ b/src/logic/BoardToken.cpp
@@ -9,7 +9,7 @@ BoardToken::BoardToken(Army army, std::string name, Attributes* attributes)
   }
 }
 
-BoardToken::~BoardToken(void) {
+BoardToken::~BoardToken() {
   delete attributes;
 }
 
@@ -37,19 +37,19 @@ void BoardToken::downgradeAttributeBy(AttributeName name, int downgradeValue) {
   getAttribute(name) -> downgradeBy(downgradeValue);
 }
 
-void BoardToken::rotateClockwise(void) {
+void BoardToken::rotateClockwise() {
   ++orientation;
 }
 
-void BoardToken::rotateAnticlockwise(void) {
+void BoardToken::rotateAnticlockwise() {
   --orientation;
 }
 
-Field* BoardToken::getField(void) {
+Field * BoardToken::getField() {
   return field;
 }
 
-Side BoardToken::getOrientation(void) {
+Side BoardToken::getOrientation() {
   return orientation;
 }
 
@@ -58,7 +58,7 @@ void BoardToken::setArmy(Army army) {
 }
 
 void BoardToken::resetArmy() {
-  this -> army -> resetValue();
+  this->army->resetValue();
 }
 
 void BoardToken::setField(Field* field) {

--- a/src/logic/BoardToken.hpp
+++ b/src/logic/BoardToken.hpp
@@ -10,24 +10,24 @@ class BoardToken : public Token
 {
 public:
   BoardToken(Army army, std::string name, Attributes* attributes = nullptr);
-  virtual ~BoardToken(void);
+  virtual ~BoardToken();
 
   void addAttribute(AttributeName name, Attribute* attribute);
   void removeAttribute(AttributeName name);
   void upgradeAttributeBy(AttributeName name, int upgradeValue = 1);
   void downgradeAttributeBy(AttributeName name, int downgradeValue = 1);
-  void rotateClockwise(void);
-  void rotateAnticlockwise(void);
+  void rotateClockwise();
+  void rotateAnticlockwise();
 
   //getters
   Attribute* getAttribute(AttributeName name);
   Attributes* getAttributes();
-  Field* getField(void);
-  Side getOrientation(void);
+  Field *getField();
+  Side getOrientation();
 
   //setters
   void setArmy(Army army);
-  void resetArmy(void);
+  void resetArmy();
   void setField(Field* field);
   void setOrientation(Side orientation);
 

--- a/src/logic/ChangeArmyUpgrader.cpp
+++ b/src/logic/ChangeArmyUpgrader.cpp
@@ -5,9 +5,9 @@ ChangeArmyUpgrader::ChangeArmyUpgrader(Module* module, bool affectsEnemies)
 }
 
 void ChangeArmyUpgrader::upgrade(BoardToken* token) {
-  token -> setArmy(module -> getArmy());
+  token -> setArmy(module->getArmy());
 }
 
 void ChangeArmyUpgrader::downgrade(BoardToken* token) {
-  token -> resetArmy();
+  token->resetArmy();
 }

--- a/src/logic/ChangeArmyUpgrader.hpp
+++ b/src/logic/ChangeArmyUpgrader.hpp
@@ -7,7 +7,6 @@ class ChangeArmyUpgrader : public Upgrader
 {
 public:
   ChangeArmyUpgrader(Module* module, bool affectsEnemies = false);
-  ~ChangeArmyUpgrader() {}
 
 protected:
   void upgrade(BoardToken *token);

--- a/src/logic/ChangeAttributeUpgrader.hpp
+++ b/src/logic/ChangeAttributeUpgrader.hpp
@@ -7,7 +7,6 @@ class ChangeAttributeUpgrader : public Upgrader
 {
 public:
   ChangeAttributeUpgrader(Module* module, AttributeName name, int changeValue, bool affectsEnemies = false);
-  ~ChangeAttributeUpgrader() {}
 
   AttributeName getAttributeToChange() const;
   int getChangeValue() const;

--- a/src/logic/Controller.cpp
+++ b/src/logic/Controller.cpp
@@ -11,7 +11,7 @@ Controller::Controller(Model* model)
 }
 
 Board* Controller::getModelBoard() {
-  return model -> getBoard();
+  return model->getBoard();
 }
 
 void Controller::initializeNewPlayer(Army army) {
@@ -22,7 +22,7 @@ void Controller::initializeNewPlayer(Army army) {
 }
 
 void Controller::drawTokensForActivePlayer() {
-  Player* player = model -> getCurrentPlayer();
+  Player* player = model->getCurrentPlayer();
   player -> drawTokens(1);
 }
 
@@ -35,17 +35,17 @@ void Controller::startBattle() {
 }
 
 void Controller::rotateClockwise(BoardToken* token) {
-  token -> rotateClockwise();
+  token->rotateClockwise();
 }
 
 void Controller::rotateAnticlockwise(BoardToken* token) {
-  token -> rotateAnticlockwise();
+  token->rotateAnticlockwise();
 }
 
 void Controller::putOnBoard(BoardToken* token, Field* field) {
   field -> setToken(token);
   token -> setField(field);
-  model -> getPlayer(token -> getArmy());
+  model -> getPlayer(token->getArmy());
 }
 
 void Controller::move(BoardToken* token, Field* destination) {
@@ -63,15 +63,15 @@ void Controller::strikeToken(BoardToken* token, int strength) {
 }
 
 void Controller::bombStrikeField(Field* epicentrum) {
-  BoardToken* token = dynamic_cast<BoardToken*>(epicentrum -> getToken());
+  BoardToken* token = dynamic_cast<BoardToken*>(epicentrum->getToken());
   if(token != nullptr) {
     token -> downgradeAttributeBy(TOUGHNESS);
   }
   Field* neighbour;
   for(int i=0; i<6; ++i) {
     neighbour = epicentrum -> getNeighbour((Side) i);
-    if(neighbour != nullptr && neighbour -> getToken() != nullptr) {
-      token = dynamic_cast<BoardToken*>(neighbour -> getToken());
+    if(neighbour != nullptr && neighbour->getToken() != nullptr) {
+      token = dynamic_cast<BoardToken*>(neighbour->getToken());
       token -> downgradeAttributeBy(TOUGHNESS);
     }
   }
@@ -81,8 +81,8 @@ void Controller::destroy(BoardToken* token) {
   model -> killToken(token);
 }
 
-void Controller::reset(void) {
-  model -> reset();
+void Controller::reset() {
+  model->reset();
 }
 
 int Controller::getRandomNumber(int i) {

--- a/src/logic/Controller.hpp
+++ b/src/logic/Controller.hpp
@@ -9,14 +9,13 @@ class Controller
 {
 public:
   Controller(Model* model);
-  ~Controller(void) {}
 
-  Board* getModelBoard(void);
+  Board *getModelBoard();
   void initializeNewPlayer(Army army);
-  void drawTokensForActivePlayer(void);
+  void drawTokensForActivePlayer();
 
   void setGameState(GameState newState);
-  void startBattle(void);
+  void startBattle();
   void rotateClockwise(BoardToken* token);
   void rotateAnticlockwise(BoardToken* token);
   void putOnBoard(BoardToken* token, Field* field);
@@ -24,7 +23,7 @@ public:
   void strikeToken(BoardToken* token, int strength);
   void bombStrikeField(Field* epicentrum);
   void destroy(BoardToken* token);
-  void reset(void);
+  void reset();
 
 private:
   Model* model;

--- a/src/logic/Field.cpp
+++ b/src/logic/Field.cpp
@@ -1,11 +1,6 @@
 #include "Field.hpp"
 
-Field::Field(void)
-{
-  token = nullptr;
-}
-
-Token* Field::getToken(void) {
+Token * Field::getToken() {
   return token;
 }
 

--- a/src/logic/Field.hpp
+++ b/src/logic/Field.hpp
@@ -9,11 +9,8 @@
 class Field
 {
 public:
-  Field(void);
-  ~Field(void) {}
-
   //getters
-  Token* getToken(void);
+  Token *getToken();
   Field* getNeighbour(const Side& side);
 
   void setToken(Token* token);

--- a/src/logic/HeadquartersToken.hpp
+++ b/src/logic/HeadquartersToken.hpp
@@ -15,7 +15,6 @@ class HeadquartersToken : public UnitToken, public ModuleToken
 {
 public:
   HeadquartersToken(Army army, std::string name, Attributes* attributes = nullptr, std::vector<Side> edges = HQ_EDGES);
-  ~HeadquartersToken() {}
 };
 
 #endif //HEADQUARTERSTOKEN_HPP

--- a/src/logic/InstantToken.cpp
+++ b/src/logic/InstantToken.cpp
@@ -12,7 +12,7 @@ BattleToken::BattleToken(Army army, Controller* controller)
 
 void BattleToken::action() {
   controller -> setGameState(BATTLE);
-  controller -> startBattle();
+  controller->startBattle();
 }
 
 

--- a/src/logic/InstantToken.hpp
+++ b/src/logic/InstantToken.hpp
@@ -9,9 +9,9 @@ class InstantToken : public Token
 {
 public:
   InstantToken(Army army, std::string name, Controller* controller);
-  virtual ~InstantToken(void) {}
 
-  virtual void action(void) = 0;
+  virtual void action() = 0;
+
 protected:
   Controller* controller;
 
@@ -22,27 +22,25 @@ protected:
   FRIEND_TEST(TokenLoaderTest, shouldCreateBombToken);
   FRIEND_TEST(TokenLoaderTest, shouldCreateGrenadeToken);
   FRIEND_TEST(TokenLoaderTest, shouldCreateSniperToken);
-
 };
 
 class BattleToken : public InstantToken
 {
 public:
   BattleToken(Army army, Controller* controller);
-  ~BattleToken(void) {}
 
-  void action(void);
+  void action();
 };
 
 class MovementToken : public InstantToken
 {
 public:
   MovementToken(Army army, Controller* controller);
-  ~MovementToken() {}
 
-  void action(void);
+  void action();
   void setTokenToMove(BoardToken* tokenToMove);
   void setDestination(Field* destination);
+
 private:
   BoardToken* tokenToMove;
   Field* destination;
@@ -52,13 +50,13 @@ class PushToken : public InstantToken
 {
 public:
   PushToken(Army army, Controller* controller);
-  ~PushToken() {}
 
-  void action(void);
+  void action();
 
   void setPushingToken(BoardToken* token);
   void setPushedToken(BoardToken* token);
   void setDestination(Field* destination);
+
 private:
   BoardToken* pusher;
   BoardToken* pushee;
@@ -69,9 +67,8 @@ class BombToken : public InstantToken
 {
 public:
   BombToken(Army army, Controller* controller);
-  ~BombToken() {}
 
-  void action(void);
+  void action();
   void setEpicentrum(Field* epicentrum);
 
 private:
@@ -82,9 +79,8 @@ class GrenadeToken : public InstantToken
 {
 public:
   GrenadeToken(Army army, Controller* controller);
-  ~GrenadeToken() {}
 
-  void action(void);
+  void action();
   void setTokenToDestroy(BoardToken* toDestroy);
 
 private:
@@ -95,9 +91,8 @@ class SniperToken : public InstantToken
 {
 public:
   SniperToken(Army army, Controller* controller);
-  ~SniperToken() {}
 
-  void action(void);
+  void action();
   void setTokenToStrike(BoardToken* toStrike);
 
 private:

--- a/src/logic/Model.cpp
+++ b/src/logic/Model.cpp
@@ -2,7 +2,7 @@
 
 Model::Model()
   : gameState(PAUSE), currentPlayerId(-1) {
-  this -> board = new Board;
+  this -> board = new Board();
 }
 
 Board* Model::getBoard() {
@@ -24,7 +24,7 @@ Player* Model::getCurrentPlayer() {
 
 Player* Model::getPlayer(Army army) {
   for (Player* p: players) {
-    if (p -> getArmy() == army) {
+    if (p->getArmy() == army) {
       return p;
     }
   }
@@ -51,12 +51,12 @@ void Model::moveToNextPlayer() {
 }
 
 void Model::killToken(BoardToken* token) {
-  Field* field = token -> getField();
+  Field* field = token->getField();
   if (field != nullptr) {
     field->setToken(nullptr);
   }
   token->setField(nullptr);
-  Player* player = getPlayer(token -> getArmy());
+  Player* player = getPlayer(token->getArmy());
   player -> killToken(token);
 }
 

--- a/src/logic/Model.hpp
+++ b/src/logic/Model.hpp
@@ -20,21 +20,20 @@ enum GameState {
 class Model
 {
 public:
-  Model(void);
-  ~Model(void) {}
+  Model();
 
   //getters
-  Board* getBoard(void);
-  GameState getGameState(void);
-  Player* getCurrentPlayer(void);
+  Board *getBoard();
+  GameState getGameState();
+  Player *getCurrentPlayer();
   Player* getPlayer(Army army);
-  int getPlayersQuantity(void);
+  int getPlayersQuantity();
 
   void setGameState(GameState newState);
   void addPlayer(Player* newPlayer);
-  void moveToNextPlayer(void);
+  void moveToNextPlayer();
   void killToken(BoardToken* token);
-  void reset(void);
+  void reset();
 
 private:
   Board* board;

--- a/src/logic/Module.hpp
+++ b/src/logic/Module.hpp
@@ -7,7 +7,6 @@ class Module : public BoardToken
 {
 public:
   Module(Army army, std::string name, Attributes* attributes = nullptr);
-  virtual ~Module() {}
 
   virtual void addBoardToken(BoardToken* token) = 0;
   virtual void removeBoardToken(BoardToken* token) = 0;

--- a/src/logic/ModuleToken.hpp
+++ b/src/logic/ModuleToken.hpp
@@ -11,7 +11,6 @@ class ModuleToken : public Module
 {
 public:
   ModuleToken(Army army, std::string name, Attributes* attributes = nullptr, std::vector<Side> activeEdges = empty);
-  virtual ~ModuleToken() {}
 
   void addBoardToken(BoardToken* token);
   void removeBoardToken(BoardToken* token);

--- a/src/logic/Player.hpp
+++ b/src/logic/Player.hpp
@@ -9,14 +9,13 @@ class Player
 {
 public:
   Player(Army army);
-  ~Player(void) {}
 
   //getters
-  Army getArmy(void);
+  Army getArmy();
   Token* getTokenOnHand(int position);
 
   void addTokens(std::vector<Token*> tokens);
-  void shuffleTokens(void);
+  void shuffleTokens();
 
   void killToken(BoardToken* token);
   void useToken(Token* token);
@@ -24,6 +23,7 @@ public:
   void drawTokens(int amount = 3);
 
   std::vector <Token*> hiddenTokens;
+
 private:
   Army army;
   std::vector <BoardToken*> tokensOnBoard;

--- a/src/logic/Token.cpp
+++ b/src/logic/Token.cpp
@@ -4,10 +4,10 @@ Token::Token(Army army, std::string name) : name(name){
   this -> army = new Attribute("army", army);
 }
 
-Army Token::getArmy(void) {
-  return (Army) army -> getValue();
+Army Token::getArmy() {
+  return (Army) army->getValue();
 }
 
-std::string Token::getName(void) {
+std::string Token::getName() {
   return name;
 }

--- a/src/logic/Token.hpp
+++ b/src/logic/Token.hpp
@@ -9,11 +9,11 @@ class Token
 {
 public:
   Token(Army army, std::string name);
-  virtual ~Token(void) {}
+  virtual ~Token() {}
 
   //getters
-  Army getArmy(void);
-  std::string getName(void);
+  Army getArmy();
+  std::string getName();
 
 protected:
   Attribute* army;

--- a/src/logic/Upgrader.cpp
+++ b/src/logic/Upgrader.cpp
@@ -1,7 +1,7 @@
 #include "Upgrader.hpp"
 
 Upgrader::Upgrader(Module* module, bool affectsEnemies)
-  : Module(module -> getArmy(), module -> getName(), module -> getAttributes()), affectsEnemies(affectsEnemies) {
+  : Module(module->getArmy(), module->getName(), module -> getAttributes()), affectsEnemies(affectsEnemies) {
   this -> module = module;
 }
 
@@ -15,7 +15,7 @@ void Upgrader::upgrade(BoardToken* token) {
 void Upgrader::downgrade(BoardToken* token) {
 }
 
-bool Upgrader::isAffectingEnemies(void) {
+bool Upgrader::isAffectingEnemies() {
   return affectsEnemies;
 }
 

--- a/src/logic/Upgrader.hpp
+++ b/src/logic/Upgrader.hpp
@@ -7,11 +7,11 @@ class Upgrader : public Module
 {
 public:
   Upgrader(Module* module, bool affectsEnemies);
-  virtual ~Upgrader();
+  ~Upgrader();
 
   virtual void addBoardToken(BoardToken* token);
   virtual void removeBoardToken(BoardToken* token);
-  bool isAffectingEnemies(void);
+  bool isAffectingEnemies();
 
 protected:
   virtual void upgrade(BoardToken *token);
@@ -19,7 +19,6 @@ protected:
 
   bool affectsEnemies;
   Module* module;
-
 };
 
 #endif //UPGRADER_HPP

--- a/src/setup/GameBox.cpp
+++ b/src/setup/GameBox.cpp
@@ -17,11 +17,11 @@ GameBox * GameBox::getInstance()
 GameBox::GameBox() {
 }
 
-int GameBox::getArmiesCount(void) {
+int GameBox::getArmiesCount() {
   return armies.size();
 }
 
-bool GameBox::isEmpty(void) {
+bool GameBox::isEmpty() {
   return getArmiesCount() == 0;
 }
 

--- a/src/setup/GameBox.hpp
+++ b/src/setup/GameBox.hpp
@@ -17,8 +17,8 @@ class GameBox
 public:
   static GameBox * getInstance();
 
-  int getArmiesCount(void);
-  bool isEmpty(void);
+  int getArmiesCount();
+  bool isEmpty();
   std::vector<Token *> getArmy(Army armyName);
 
 protected:
@@ -43,7 +43,6 @@ private:
   FRIEND_TEST(GameBoxTest, shouldThrowExceptionWhenTryingToAddTokenOfArmyThatIsNotInTheBox);
   FRIEND_TEST(GameBoxTest, shouldThrowExceptionWhenAlreadySuchArmyInTheBox);
   FRIEND_TEST(GameBoxTest, shouldAddEmptyArmyToTheBox);
-
 };
 
 #endif // GAME_BOX_H

--- a/src/setup/Json.cpp
+++ b/src/setup/Json.cpp
@@ -3,13 +3,10 @@
 #include <QStringList>
 #include <QVector>
 
-Json::Json(void) : QJsonObject() {
+Json::Json() : QJsonObject() {
 }
 
 Json::Json(QJsonObject object) : QJsonObject(object) {
-}
-
-Json::~Json(void) {
 }
 
 std::string Json::getStringValue(std::string key) {
@@ -62,7 +59,7 @@ bool Json::contains(std::string key) {
   return QJsonObject::contains(QString::fromStdString(key));
 }
 
-std::vector<std::string> Json::getKeys(void) {
+std::vector <std::string> Json::getKeys() {
   std::vector<QString> qstringKeys = keys().toVector().toStdVector();
   std::vector<std::string> keys;
   for(int currentKey = 0; currentKey < qstringKeys.size(); currentKey++) {

--- a/src/setup/Json.hpp
+++ b/src/setup/Json.hpp
@@ -11,9 +11,8 @@
 class Json : public QJsonObject
 {
 public:
-  Json(void);
+  Json();
   Json(QJsonObject object);
-  ~Json(void);
 
   std::string getStringValue(std::string key);
   virtual int getIntegerValue(std::string key);
@@ -24,7 +23,7 @@ public:
   std::vector<int> getIntegerArray(std::string key);
 
   bool contains(std::string key);
-  virtual std::vector<std::string> getKeys(void);
+  virtual std::vector <std::string> getKeys();
 
 protected:
   QJsonValue takeFromJson(std::string key);

--- a/test/BoardTest.cpp
+++ b/test/BoardTest.cpp
@@ -9,16 +9,6 @@ using ::testing::Test;
 class BoardTest : public Test
 {
 protected:
-  BoardTest(void) {
-    board = new Board;
-  }
-  ~BoardTest(void) {
-    delete board;
-  }
-
-  virtual void SetUp(void) {}
-  virtual void TearDown(void) {}
-  
   Side increment(Side edge) {
     return ++edge;
   }
@@ -26,11 +16,11 @@ protected:
     return --edge;
   }
 
-  Board* board;
+  Board board;
 };
 
 TEST_F(BoardTest, shouldCreateMiddleRing) {
-  Field* middle = board -> getMiddleField();
+  Field* middle = board.getMiddleField();
   //REVIEW: what is wrong with for(Side side = Side::NORTH; side <= Side::whatever; side++)
   //TODO: override operator <= for Side to enable for loop usage
   Side side = Side::NORTH;
@@ -51,8 +41,8 @@ TEST_F(BoardTest, shouldCreateMiddleRing) {
 TEST_F(BoardTest, shouldCreateOutsideRing) {
   Side side = Side::NORTH;
   do {
-    Field* root = board -> getMiddleField() -> getNeighbour(side);
-    Field* rootNext = board -> getMiddleField() -> getNeighbour(increment(side));
+    Field* root = board.getMiddleField()-> getNeighbour(side);
+    Field* rootNext = board.getMiddleField()-> getNeighbour(increment(side));
     Field* first = root -> getNeighbour(side);
     Field* second = root -> getNeighbour(increment(side));
     Field* third = rootNext -> getNeighbour(increment(side));

--- a/test/BoardTokenTest.cpp
+++ b/test/BoardTokenTest.cpp
@@ -25,24 +25,20 @@ protected:
 
   BoardToken* token;
   Attribute* initiative;
-
-  virtual void SetUp() {}
-
-  virtual void TearDown() {}
 };
 
 TEST_F(BoardTokenTest, testGetAttribute) {
   Attribute* attribute = token -> getAttribute(INITIATIVE);
   ASSERT_EQ(initiative, attribute);
-  ASSERT_EQ(initiative -> getName(), attribute -> getName());
-  ASSERT_EQ(initiative -> getValue(), attribute -> getValue());
+  ASSERT_EQ(initiative->getName(), attribute->getName());
+  ASSERT_EQ(initiative->getValue(), attribute->getValue());
 }
 
 TEST_F(BoardTokenTest, testModifyAttribute) {
   token -> upgradeAttributeBy(INITIATIVE);
-  ASSERT_EQ(ATTRIBUTE_VALUE + 1, token -> getAttribute(INITIATIVE) -> getValue());
+  ASSERT_EQ(ATTRIBUTE_VALUE + 1, token->getAttribute(INITIATIVE)->getValue());
   token -> downgradeAttributeBy(INITIATIVE);
-  ASSERT_EQ(ATTRIBUTE_VALUE, token -> getAttribute(INITIATIVE) -> getValue());
+  ASSERT_EQ(ATTRIBUTE_VALUE, token->getAttribute(INITIATIVE)->getValue());
 }
 
 TEST_F(BoardTokenTest, testRemoveAttribute) {
@@ -52,22 +48,22 @@ TEST_F(BoardTokenTest, testRemoveAttribute) {
 }
 
 TEST_F(BoardTokenTest, testGetOrientation) {
-  ASSERT_EQ(Side::NORTH, token -> getOrientation());
+  ASSERT_EQ(Side::NORTH, token->getOrientation());
 }
 
 TEST_F(BoardTokenTest, testSetOrientation) {
   token -> setOrientation(Side::SOUTH);
-  ASSERT_EQ(Side::SOUTH, token -> getOrientation());
+  ASSERT_EQ(Side::SOUTH, token->getOrientation());
 }
 
 TEST_F(BoardTokenTest, testRotateClockwise) {
   token -> setOrientation(Side::SOUTH);
-  token -> rotateClockwise();
-  ASSERT_EQ(Side::SOUTH_WEST, token -> getOrientation());
+  token->rotateClockwise();
+  ASSERT_EQ(Side::SOUTH_WEST, token->getOrientation());
 }
 
 TEST_F(BoardTokenTest, testRotateAnticlockwise) {
   token -> setOrientation(Side::SOUTH);
-  token -> rotateAnticlockwise();
-  ASSERT_EQ(Side::SOUTH_EAST, token -> getOrientation());
+  token->rotateAnticlockwise();
+  ASSERT_EQ(Side::SOUTH_EAST, token->getOrientation());
 }

--- a/test/ControllerTest.cpp
+++ b/test/ControllerTest.cpp
@@ -11,19 +11,8 @@ using ::testing::Test;
 class ControllerTest : public Test
 {
 protected:
-  ControllerTest(void) {
-    model = new Model;
-    controller = new Controller(model);
-  }
-  ~ControllerTest(void) {
-    delete controller;
-    delete model;
-  }
-  Controller* controller;
-  Model* model;
-
-  virtual void SetUp(void) {}
-  virtual void TearDown(void) {}
+  Model model;
+  Controller controller {&model};
 
   BoardToken* createBoardTokenWithToughness();
 };
@@ -36,39 +25,38 @@ BoardToken* ControllerTest::createBoardTokenWithToughness() {
 }
 
 TEST_F(ControllerTest, shouldRotateToken) {
-  BoardToken* token = new BoardToken(MOLOCH, "soldier");
-  EXPECT_EQ(Side::NORTH, token -> getOrientation());
-  controller -> rotateClockwise(token);
-  EXPECT_EQ(Side::NORTH_EAST, token -> getOrientation());
-  controller -> rotateAnticlockwise(token);
-  EXPECT_EQ(Side::NORTH, token -> getOrientation());
-  delete token;
-}
+  BoardToken token {MOLOCH, "soldier"};
+  EXPECT_EQ(Side::NORTH, token.getOrientation());
+  controller.rotateClockwise(&token);
+  EXPECT_EQ(Side::NORTH_EAST, token.getOrientation());
+  controller.rotateAnticlockwise(&token);
+  EXPECT_EQ(Side::NORTH, token.getOrientation());
+};
 
 TEST_F(ControllerTest, shouldPutTokenOnBoard) {
-  Field* field = new Field;
-  BoardToken* token = new BoardToken(MOLOCH, "solder");
-  controller -> putOnBoard(token, field);
-  EXPECT_EQ(token, field -> getToken());
-  EXPECT_EQ(field, token -> getField());
-}
+  Field field;
+  BoardToken token {MOLOCH, "solder"};
+  controller.putOnBoard(&token, &field);
+  EXPECT_EQ(&token, field.getToken());
+  EXPECT_EQ(&field, token.getField());
+};
 
 TEST_F(ControllerTest, shouldMoveToken) {
-  BoardToken* token = new BoardToken(MOLOCH, "solder");
-  Field* field = new Field;
-  Field* destination = new Field;
-  token -> setField(field);
-  field -> setToken(token);
-  controller -> move(token, destination);
-  EXPECT_EQ(nullptr, field -> getToken());
-  EXPECT_EQ(destination, token -> getField());
-  EXPECT_EQ(token, destination -> getToken());
-}
+  BoardToken token {MOLOCH, "solder"};
+  Field field;
+  Field destination;
+  token.setField(&field);
+  field.setToken(&token);
+  controller.move(&token, &destination);
+  EXPECT_EQ(nullptr, field.getToken());
+  EXPECT_EQ(&destination, token.getField());
+  EXPECT_EQ(&token, destination.getToken());
+};
 
 TEST_F(ControllerTest, shouldStrikeToken) {
   BoardToken* token = createBoardTokenWithToughness();
-  controller -> strikeToken(token, 1);
-  EXPECT_EQ(1, token -> getAttribute(TOUGHNESS) -> getValue());
+  controller.strikeToken(token, 1);
+  EXPECT_EQ(1, token->getAttribute(TOUGHNESS)->getValue());
 }
 
 //TODO: split into separate tests
@@ -85,18 +73,18 @@ TEST_F(ControllerTest, shouldBombStrikeAreaOfOneFieldRadius) {
   BoardToken* thirdToken = createBoardTokenWithToughness();
   BoardToken* fourthToken = createBoardTokenWithToughness();
   BoardToken* fifthToken = createBoardTokenWithToughness();
-  controller -> putOnBoard(firstToken, epicentrum);
-  controller -> putOnBoard(secondToken, north);
-  controller -> putOnBoard(thirdToken, south);
-  controller -> putOnBoard(fourthToken, farNorth);
-  controller -> putOnBoard(fifthToken, farSouth);
+  controller.putOnBoard(firstToken, epicentrum);
+  controller.putOnBoard(secondToken, north);
+  controller.putOnBoard(thirdToken, south);
+  controller.putOnBoard(fourthToken, farNorth);
+  controller.putOnBoard(fifthToken, farSouth);
 
-  controller -> bombStrikeField(epicentrum);
-  EXPECT_EQ(1, firstToken -> getAttribute(TOUGHNESS) -> getValue());
-  EXPECT_EQ(1, secondToken -> getAttribute(TOUGHNESS) -> getValue());
-  EXPECT_EQ(1, thirdToken -> getAttribute(TOUGHNESS) -> getValue());
-  EXPECT_EQ(2, fourthToken -> getAttribute(TOUGHNESS) -> getValue());
-  EXPECT_EQ(2, fifthToken -> getAttribute(TOUGHNESS) -> getValue());
+  controller.bombStrikeField(epicentrum);
+  EXPECT_EQ(1, firstToken->getAttribute(TOUGHNESS)->getValue());
+  EXPECT_EQ(1, secondToken->getAttribute(TOUGHNESS)->getValue());
+  EXPECT_EQ(1, thirdToken->getAttribute(TOUGHNESS)->getValue());
+  EXPECT_EQ(2, fourthToken->getAttribute(TOUGHNESS)->getValue());
+  EXPECT_EQ(2, fifthToken->getAttribute(TOUGHNESS)->getValue());
   delete fifthToken;
   delete fourthToken;
   delete thirdToken;
@@ -110,13 +98,12 @@ TEST_F(ControllerTest, shouldBombStrikeAreaOfOneFieldRadius) {
 }
 
 TEST_F(ControllerTest, shouldResetGame) {
-  Player* player = new Player(MOLOCH);
-  model -> addPlayer(player);
-  controller -> setGameState(GAME);
-  EXPECT_EQ(GAME, model -> getGameState());
-  EXPECT_FALSE(model -> players.empty());
-  controller -> reset();
-  EXPECT_EQ(PAUSE, model -> getGameState());
-  EXPECT_TRUE(model -> players.empty());
-  delete player;
-}
+  Player player {MOLOCH};
+  model.addPlayer(&player);
+  controller.setGameState(GAME);
+  EXPECT_EQ(GAME, model.getGameState());
+  EXPECT_FALSE(model.players.empty());
+  controller.reset();
+  EXPECT_EQ(PAUSE, model.getGameState());
+  EXPECT_TRUE(model.players.empty());
+};

--- a/test/FieldTest.cpp
+++ b/test/FieldTest.cpp
@@ -9,56 +9,40 @@ using ::testing::Test;
 class FieldTest : public Test
 {
 protected:
-  FieldTest(void) {
-    field = new Field;
-  }
-  ~FieldTest(void) {
-    delete field;
-  }
-
-  virtual void SetUp(void) {}
-  virtual void TearDown(void) {}
-
-  Field* field;
+  Field field;
 };
 
 TEST_F(FieldTest, shouldSetToken) {
-  BoardToken* token = new BoardToken(MOLOCH, "soldier");
-  field -> setToken(token);
-  EXPECT_EQ(token, field -> getToken());
-  delete token;
-}
+  BoardToken token {MOLOCH, "soldier"};
+  field.setToken(&token);
+  EXPECT_EQ(&token, field.getToken());
+};
 
 TEST_F(FieldTest, shouldGetToken) {
-  Token* newToken = new Token(MOLOCH, "soldier");
-  field -> setToken(newToken);
-  Token* token = field -> getToken();
-  EXPECT_EQ(newToken, token);
-  EXPECT_EQ(newToken -> getName(), token -> getName());
-  delete token;
-}
+  Token newToken {MOLOCH, "soldier"};
+  field.setToken(&newToken);
+  Token* token = field.getToken();
+  EXPECT_EQ(&newToken, token);
+  EXPECT_EQ(newToken.getName(), token->getName());
+};
 
 TEST_F(FieldTest, shouldAddNeighbour) {
-  Field* neighbour = new Field;
-  field -> addNeighbour(neighbour, Side::NORTH);
-  EXPECT_EQ(neighbour, field -> getNeighbour(Side::NORTH));
-  delete neighbour;
+  Field neighbour;
+  field.addNeighbour(&neighbour, Side::NORTH);
+  EXPECT_EQ(&neighbour, field.getNeighbour(Side::NORTH));
 }
 
 TEST_F(FieldTest, shouldGetNeighbour) {
-  Token* firstToken = new Token(MOLOCH, "first token");
-  Token* secondToken = new Token(MOLOCH, "second token");
-  Field* newNeighbour = new Field;
-  newNeighbour -> setToken(secondToken);
-  field -> setToken(firstToken);
-  EXPECT_EQ("first token", field -> getToken() -> getName());
-  field -> addNeighbour(newNeighbour, Side::NORTH);
-  Field* neighbour = field -> getNeighbour(Side::SOUTH);
+  Token firstToken {MOLOCH, "first token"};
+  Token secondToken {MOLOCH, "second token"};
+  Field newNeighbour;
+  newNeighbour.setToken(&secondToken);
+  field.setToken(&firstToken);
+  EXPECT_EQ("first token", field.getToken() -> getName());
+  field.addNeighbour(&newNeighbour, Side::NORTH);
+  Field* neighbour = field.getNeighbour(Side::SOUTH);
   EXPECT_EQ(nullptr, neighbour);
-  neighbour = field -> getNeighbour(Side::NORTH);
-  ASSERT_EQ(newNeighbour, neighbour);
-  EXPECT_EQ("second token", neighbour -> getToken() -> getName());
-  delete neighbour;
-  delete secondToken;
-  delete firstToken;
-}
+  neighbour = field.getNeighbour(Side::NORTH);
+  ASSERT_EQ(&newNeighbour, neighbour);
+  EXPECT_EQ("second token", neighbour->getToken()->getName());
+};

--- a/test/GameBoxTest.cpp
+++ b/test/GameBoxTest.cpp
@@ -10,13 +10,6 @@ using ::testing::Test;
 
 class GameBoxTest : public Test {
 protected:
-  GameBoxTest() {}
-
-  virtual ~GameBoxTest() {}
-
-  virtual void SetUp() {}
-  virtual void TearDown() {}
-
   //TODO: use it
   std::vector<Token*> createNewArmy(Army armyName) {
     Token* someToken = new BoardToken(armyName, "someToken", new Attributes);
@@ -66,16 +59,16 @@ TEST_F(GameBoxTest, shouldGetArmyFromTheBox) {
   gameBox.armies.insert(std::make_pair(armyName, army));
   std::vector<Token *> returnedArmy = gameBox.getArmy(armyName);
   ASSERT_EQ(army.size(), returnedArmy.size());
-  ASSERT_EQ(armyName, returnedArmy[0] -> getArmy());
+  ASSERT_EQ(armyName, returnedArmy[0]->getArmy());
   ASSERT_TRUE(dynamic_cast<BoardToken *>(returnedArmy[0]));
   ASSERT_EQ(&attributes, dynamic_cast<BoardToken *>(returnedArmy[0]) -> getAttributes());
-  ASSERT_EQ(tokenName, dynamic_cast<BoardToken *>(returnedArmy[0]) -> getName());
+  ASSERT_EQ(tokenName, dynamic_cast<BoardToken *>(returnedArmy[0])->getName());
 }
 
 TEST_F(GameBoxTest, shouldThrowExceptionWhenNoSuchArmyInTheBox) {
-  ASSERT_TRUE(GameBox::getInstance() -> isEmpty());
+  ASSERT_TRUE(GameBox::getInstance()->isEmpty());
   ASSERT_THROW(GameBox::getInstance() -> getArmy(OUTPOST), NoSuchArmyInBoxException);
-  ASSERT_TRUE(GameBox::getInstance() -> isEmpty());
+  ASSERT_TRUE(GameBox::getInstance()->isEmpty());
 }
 
 TEST_F(GameBoxTest, shouldAddArmyToTheBox) {
@@ -94,10 +87,10 @@ TEST_F(GameBoxTest, shouldAddArmyToTheBox) {
 
   std::vector<Token*> returnedArmy = gameBox.getArmy(armyName);
   ASSERT_EQ(army.size(), returnedArmy.size());
-  ASSERT_EQ(armyName, returnedArmy[0] -> getArmy());
+  ASSERT_EQ(armyName, returnedArmy[0]->getArmy());
   ASSERT_TRUE(dynamic_cast<BoardToken *>(returnedArmy[0]));
   ASSERT_EQ(&attributes, dynamic_cast<BoardToken *>(returnedArmy[0]) -> getAttributes());
-  ASSERT_EQ(tokenName, dynamic_cast<BoardToken *>(returnedArmy[0]) -> getName());
+  ASSERT_EQ(tokenName, dynamic_cast<BoardToken *>(returnedArmy[0])->getName());
 }
 
 TEST_F(GameBoxTest, shouldThrowExceptionWhenAlreadySuchArmyInTheBox) {
@@ -135,7 +128,7 @@ TEST_F(GameBoxTest, shouldAddTokenToTheArmy) {
   //TODO: these three assertions are used in some tests, wrap them into a method but first read the googletest documentation
   ASSERT_TRUE(dynamic_cast<BoardToken *>(returnedArmy[0]));
   ASSERT_EQ(&attributes, dynamic_cast<BoardToken *>(returnedArmy[0]) -> getAttributes());
-  ASSERT_EQ(tokenName, dynamic_cast<BoardToken *>(returnedArmy[0]) -> getName());
+  ASSERT_EQ(tokenName, dynamic_cast<BoardToken *>(returnedArmy[0])->getName());
 }
 
 TEST_F(GameBoxTest, shouldThrowExceptionWhenTryingToAddTokenOfArmyThatIsNotInTheBox) {

--- a/test/HeadquartersTest.cpp
+++ b/test/HeadquartersTest.cpp
@@ -10,37 +10,28 @@ using ::testing::Test;
 class HeadquartersTest : public Test
 {
 protected:
-  HeadquartersTest(void) {
-    hq = new HeadquartersToken(HEGEMONY, "HQ", nullptr);
-  }
-  ~HeadquartersTest(void) {
-    delete hq;
-  }
-  virtual void SetUp(void) {}
-  virtual void TearDown(void) {}
-
-  HeadquartersToken* hq;
+  HeadquartersToken hq {HEGEMONY, "HQ", nullptr};
 };
 
 TEST_F(HeadquartersTest, shouldHaveAllEdgesActiveByDefault) {
   Side side = Side::NORTH;
   //TODO: custom matcher from gmock https://code.google.com/p/googlemock/wiki/V1_7_CookBook#Writing_New_Matchers_Quickly
   do {
-    EXPECT_TRUE(hq -> isEdgeActive(side));
+    EXPECT_TRUE(hq.isEdgeActive(side));
     ++side;
   } while (side != Side::NORTH);
 }
 
 TEST_F(HeadquartersTest, shouldHaveInitiativeZeroByDefault) {
-  Attribute* initiative = hq -> UnitToken::getAttribute(INITIATIVE);
+  Attribute* initiative = hq.UnitToken::getAttribute(INITIATIVE);
   ASSERT_NE(nullptr, initiative);
-  EXPECT_EQ(0, initiative -> getValue());
+  EXPECT_EQ(0, initiative->getValue());
 }
 
 TEST_F(HeadquartersTest, shouldAttackInAllDirections) {
   Side side = Side::NORTH;
   do {
-    EXPECT_EQ(1, hq -> getEdgeAttributes(side) -> getAttribute(MELEE) -> getValue());
+    EXPECT_EQ(1, hq.getEdgeAttributes(side)->getAttribute(MELEE)->getValue());
   } while (side != Side::NORTH);
 }
 
@@ -50,18 +41,18 @@ TEST_F(HeadquartersTest, shouldUpgradeBoardTokenBaseAttribute) {
   Attribute* initiative = new Attribute("initiative", 1);
   token -> addAttribute(INITIATIVE, initiative);
   borgoHQ -> addBoardToken(token);
-  EXPECT_EQ(2, token -> getAttribute(INITIATIVE) -> getValue());
+  EXPECT_EQ(2, token->getAttribute(INITIATIVE)->getValue());
 }
 
 TEST_F(HeadquartersTest, shouldUpgradeUnitTokenEdgeAttribute) {
-  Module* hegemonyHQ = new ChangeAttributeUpgrader(hq, MELEE, 1);
+  Module* hegemonyHQ = new ChangeAttributeUpgrader(&hq, MELEE, 1);
   UnitToken* token = new UnitToken(HEGEMONY, "token", new Attributes);
   Attribute* melee = new Attribute("melee", 1);
   Attributes* northEdgeAttributes = new Attributes;
   northEdgeAttributes -> addAttribute(MELEE, melee);
   token -> setEdgeAttributes(Side::NORTH, northEdgeAttributes);
   hegemonyHQ -> addBoardToken(token);
-  EXPECT_EQ(2, token -> getEdgeAttributes(Side::NORTH) -> getAttribute(MELEE) -> getValue());
+  EXPECT_EQ(2, token->getEdgeAttributes(Side::NORTH)->getAttribute(MELEE)->getValue());
 }
 
 TEST_F(HeadquartersTest, shouldAddAttributeToBoardToken) {
@@ -69,5 +60,5 @@ TEST_F(HeadquartersTest, shouldAddAttributeToBoardToken) {
   BoardToken* token = new BoardToken(OUTPOST, "token", new Attributes);
   outpostHQ -> addBoardToken(token);
   ASSERT_NE(nullptr, token -> getAttribute(MOTHER));
-  EXPECT_EQ(1, token -> getAttribute(MOTHER) -> getValue());
+  EXPECT_EQ(1, token->getAttribute(MOTHER)->getValue());
 }

--- a/test/InstantTokenTest.cpp
+++ b/test/InstantTokenTest.cpp
@@ -14,22 +14,10 @@ using ::testing::Test;
 class InstantTokenTest : public Test
 {
 protected:
-  InstantTokenTest(void) {
-    model = new Model();
-    controller = new Controller(model);
-  }
-  ~InstantTokenTest(void) {
-    delete controller;
-    delete model;
-  }
-
-  virtual void SetUp(void) {}
-  virtual void TearDown(void) {}
-
   BoardToken* createBoardTokenWithToughness();
 
-  Model* model;
-  Controller* controller;
+  Model model;
+  Controller controller {&model};
 };
 
 BoardToken* InstantTokenTest::createBoardTokenWithToughness() {
@@ -40,32 +28,31 @@ BoardToken* InstantTokenTest::createBoardTokenWithToughness() {
 }
 
 TEST_F(InstantTokenTest, shouldCauseBattle) {
-  BattleToken* battle = new BattleToken(MOLOCH, controller);
-  ASSERT_EQ(PAUSE, model -> getGameState());
-  battle -> action();
-  EXPECT_EQ(BATTLE, model -> getGameState());
-  delete battle;
-}
+  BattleToken battle {MOLOCH, &controller};
+  ASSERT_EQ(PAUSE, model.getGameState());
+  battle.action();
+  EXPECT_EQ(BATTLE, model.getGameState());
+};
 
 TEST_F(InstantTokenTest, shouldMoveToken) {
-  MovementToken* movement = new MovementToken(MOLOCH, controller);
+  MovementToken* movement = new MovementToken(MOLOCH, &controller);
   BoardToken* token = new BoardToken(MOLOCH, "soldier");
   Field* field = new Field;
   Field* destination = new Field;
   token -> setField(field);
   movement -> setTokenToMove(token);
   movement -> setDestination(destination);
-  movement -> action();
-  EXPECT_NE(field, token -> getField());
-  EXPECT_EQ(nullptr, field -> getToken());
-  EXPECT_EQ(destination, token -> getField());
-  EXPECT_EQ(token, destination -> getToken());
+  movement->action();
+  EXPECT_NE(field, token->getField());
+  EXPECT_EQ(nullptr, field->getToken());
+  EXPECT_EQ(destination, token->getField());
+  EXPECT_EQ(token, destination->getToken());
   delete field;
   delete movement;
 }
 
 TEST_F(InstantTokenTest, shouldPushToken) {
-  PushToken* push = new PushToken(MOLOCH, controller);
+  PushToken* push = new PushToken(MOLOCH, &controller);
   BoardToken* pusher = new BoardToken(MOLOCH, "soldier");
   BoardToken* pushee = new BoardToken(OUTPOST, "soldier");
   Field* pusherField = new Field;
@@ -76,10 +63,10 @@ TEST_F(InstantTokenTest, shouldPushToken) {
   push -> setPushingToken(pusher);
   push -> setPushedToken(pushee);
   push -> setDestination(destination);
-  push -> action();
-  EXPECT_NE(pusheeField, pushee -> getField());
-  EXPECT_EQ(destination, pushee -> getField());
-  EXPECT_EQ(pushee, destination -> getToken());
+  push->action();
+  EXPECT_NE(pusheeField, pushee->getField());
+  EXPECT_EQ(destination, pushee->getField());
+  EXPECT_EQ(pushee, destination->getToken());
   delete pusherField;
   delete pusheeField;
   delete pusher;
@@ -88,7 +75,7 @@ TEST_F(InstantTokenTest, shouldPushToken) {
 }
 
 TEST_F(InstantTokenTest, shouldBombStrikeField) {
-  BombToken* bomb = new BombToken(MOLOCH, controller);
+  BombToken* bomb = new BombToken(MOLOCH, &controller);
   BoardToken* firstToken = createBoardTokenWithToughness();
   BoardToken* secondToken = createBoardTokenWithToughness();
   Field* firstField = new Field;
@@ -100,25 +87,26 @@ TEST_F(InstantTokenTest, shouldBombStrikeField) {
   secondField -> setToken(secondToken);
   secondToken -> setField(secondField);
 
-  bomb -> setEpicentrum(firstToken -> getField());
-  bomb -> action();
-  EXPECT_EQ(1, firstToken -> getAttribute(TOUGHNESS) -> getValue());
-  EXPECT_EQ(1, secondToken -> getAttribute(TOUGHNESS) -> getValue());
+  bomb -> setEpicentrum(firstToken->getField());
+  bomb->action();
+  EXPECT_EQ(1, firstToken->getAttribute(TOUGHNESS)->getValue());
+  EXPECT_EQ(1, secondToken->getAttribute(TOUGHNESS)->getValue());
   delete firstField;
   delete secondField;
   delete bomb;
 }
 
 TEST_F(InstantTokenTest, shouldDestroyToken) {
-  GrenadeToken* grenade = new GrenadeToken(BORGO, controller);
+  GrenadeToken* grenade = new GrenadeToken(BORGO, &controller);
   Player* player = new Player(MOLOCH);
-  model -> addPlayer(player);
+  model.addPlayer(player);
   BoardToken* token = new BoardToken(MOLOCH, "soldier");
   Field* field = new Field;
   token -> setField(field);
   field -> setToken(token);
   grenade -> setTokenToDestroy(token);
-  grenade -> action();
+  grenade->action();
+  //FIXME: uncomment this lines
 //  ASSERT_FALSE(model -> usedTokens.empty());
 //  EXPECT_EQ(token, model -> usedTokens[0]);
   delete token;
@@ -128,12 +116,12 @@ TEST_F(InstantTokenTest, shouldDestroyToken) {
 TEST_F(InstantTokenTest, shouldStrikeToken) {
 //  Controller* controller = new Controller(new Model);
 //  MockController controller;
-  SniperToken* sniper = new SniperToken(OUTPOST, controller);
+  SniperToken* sniper = new SniperToken(OUTPOST, &controller);
   BoardToken* token = createBoardTokenWithToughness();
   sniper -> setTokenToStrike(token);
-  sniper -> action();
+  sniper->action();
 //  EXPECT_CALL(controller, strikeToken(token,1))
 //      .Times(1);
-  EXPECT_EQ(1, token -> getAttribute(TOUGHNESS) -> getValue());
+  EXPECT_EQ(1, token->getAttribute(TOUGHNESS)->getValue());
   delete sniper;
 }

--- a/test/JsonTest.cpp
+++ b/test/JsonTest.cpp
@@ -8,17 +8,6 @@ using ::testing::Test;
 
 class JsonTest : public Test {
 protected:
-  JsonTest() {
-    json = new Json();
-  }
-
-  virtual ~JsonTest() {
-    delete json;
-  }
-
-  virtual void SetUp() {}
-  virtual void TearDown() {}
-
   void insertString(void);
   void insertInteger(void);
   void insertBoolean(void);
@@ -30,25 +19,25 @@ protected:
 
   void assertKeyFound(std::vector<std::string> keys, std::string keyToFind);
 
-  Json* json;
+  Json json;
 };
 
 void JsonTest::insertString(void) {
-  json -> insert(QString::fromStdString(STRING_KEY), QString::fromStdString(STRING_VALUE));
+  json.insert(QString::fromStdString(STRING_KEY), QString::fromStdString(STRING_VALUE));
 }
 
 void JsonTest::insertInteger(void) {
-  json -> insert(QString::fromStdString(INTEGER_KEY), INTEGER_VALUE);
+  json.insert(QString::fromStdString(INTEGER_KEY), INTEGER_VALUE);
 }
 
 void JsonTest::insertBoolean(void) {
-  json -> insert(QString::fromStdString(BOOLEAN_KEY), BOOLEAN_VALUE);
-  json -> insert(QString::fromStdString(SECOND_BOOLEAN_KEY), SECOND_BOOLEAN_VALUE);
+  json.insert(QString::fromStdString(BOOLEAN_KEY), BOOLEAN_VALUE);
+  json.insert(QString::fromStdString(SECOND_BOOLEAN_KEY), SECOND_BOOLEAN_VALUE);
 }
 
 void JsonTest::insertObject(void) {
   QJsonObject object = prepareObject();
-  json -> insert(QString::fromStdString(OBJECT_KEY), object);
+  json.insert(QString::fromStdString(OBJECT_KEY), object);
 }
 
 QJsonObject JsonTest::prepareObject(void) {
@@ -65,7 +54,7 @@ int JsonTest::insertArray(void) {
   QJsonArray array;
   for(int currentObject = 0; currentObject < numberOfObjectsToInsert; currentObject++)
     array.push_back(prepareObject());
-  json -> insert(QString::fromStdString(ARRAY_KEY), array);
+  json.insert(QString::fromStdString(ARRAY_KEY), array);
 
   return numberOfObjectsToInsert;
 }
@@ -76,7 +65,7 @@ int JsonTest::insertStringArray(void) {
   QJsonArray array;
   for(int currentString = 0; currentString < numberOfStringsToInsert; currentString++)
     array.push_back(QJsonValue(QString::fromStdString(STRING_VALUE)));
-  json -> insert(QString::fromStdString(STRING_ARRAY_KEY), array);
+  json.insert(QString::fromStdString(STRING_ARRAY_KEY), array);
 
   return numberOfStringsToInsert;
 }
@@ -87,44 +76,44 @@ int JsonTest::insertIntegerArray(void) {
   QJsonArray array;
   for(int currentInteger = 0; currentInteger < numberOfIntegersToInsert; currentInteger++)
     array.push_back(QJsonValue(INTEGER_VALUE));
-  json -> insert(QString::fromStdString(INTEGER_ARRAY_KEY), array);
+  json.insert(QString::fromStdString(INTEGER_ARRAY_KEY), array);
 
   return numberOfIntegersToInsert;
 }
 
 TEST_F(JsonTest, shouldGetStringValueFromJson) {
   insertString();
-  std::string returnedStringValue = json -> getStringValue(STRING_KEY);
+  std::string returnedStringValue = json.getStringValue(STRING_KEY);
   ASSERT_EQ(STRING_VALUE, returnedStringValue);
 }
 
 TEST_F(JsonTest, shouldGetIntegerValueFromJson) {
   insertInteger();
-  int returnedIntegerValue = json -> getIntegerValue(INTEGER_KEY);
+  int returnedIntegerValue = json.getIntegerValue(INTEGER_KEY);
   ASSERT_EQ(INTEGER_VALUE, returnedIntegerValue);
 }
 
 TEST_F(JsonTest, shouldReturnZeroByDefaultWhenAskedForIntegerWhenNoSuchKey) {
-  bool returnedIntegerValue = json -> getBooleanValue(INTEGER_KEY);
+  bool returnedIntegerValue = json.getBooleanValue(INTEGER_KEY);
   ASSERT_EQ(0, returnedIntegerValue);
 }
 
 TEST_F(JsonTest, shouldGetBooleanValueFromJson) {
   insertBoolean();
-  bool returnedBooleanValue = json -> getBooleanValue(BOOLEAN_KEY);
+  bool returnedBooleanValue = json.getBooleanValue(BOOLEAN_KEY);
   ASSERT_EQ(BOOLEAN_VALUE, returnedBooleanValue);
 }
 
 TEST_F(JsonTest, shouldReturnFalseByDefaultWhenAskedForBooleanWhenNoSuchKey) {
   insertInteger();
-  bool returnedBooleanValue = json -> getBooleanValue(BOOLEAN_KEY);
+  bool returnedBooleanValue = json.getBooleanValue(BOOLEAN_KEY);
   ASSERT_FALSE(returnedBooleanValue);
 }
 
 TEST_F(JsonTest, shouldGetObjectFromJson) {
   insertObject();
 
-  Json returnedObject = json -> getObject(OBJECT_KEY);
+  Json returnedObject = json.getObject(OBJECT_KEY);
 
   std::string returnedStringValue = returnedObject.getStringValue(STRING_KEY);
   bool returnedBooleanValue = returnedObject.getBooleanValue(BOOLEAN_KEY);
@@ -138,7 +127,7 @@ TEST_F(JsonTest, shouldGetObjectFromJson) {
 TEST_F(JsonTest, shouldGetArrayOfObjectsFromJson) {
   int numberOfObjectsInArray = insertArray();
 
-  std::vector<Json> returnedArrayOfObjects = json -> getArray(ARRAY_KEY);
+  std::vector<Json> returnedArrayOfObjects = json.getArray(ARRAY_KEY);
   ASSERT_EQ(numberOfObjectsInArray, returnedArrayOfObjects.size());
 
   std::string returnedStringValue;
@@ -159,7 +148,7 @@ TEST_F(JsonTest, shouldGetArrayOfObjectsFromJson) {
 TEST_F(JsonTest, shouldGetArrayOfStringsFromJson) {
   int numberOfStringsInArray = insertStringArray();
 
-  std::vector<std::string> returnedArrayOfStrings = json -> getStringArray(STRING_ARRAY_KEY);
+  std::vector<std::string> returnedArrayOfStrings = json.getStringArray(STRING_ARRAY_KEY);
   ASSERT_EQ(numberOfStringsInArray, returnedArrayOfStrings.size());
 
   std::string returnedStringValue;
@@ -173,7 +162,7 @@ TEST_F(JsonTest, shouldGetArrayOfStringsFromJson) {
 TEST_F(JsonTest, shouldGetArrayOfIntegersFromJson) {
   int numberOfIntegersInArray = insertIntegerArray();
 
-  std::vector<int> returnedArrayOfIntegers = json -> getIntegerArray(INTEGER_ARRAY_KEY);
+  std::vector<int> returnedArrayOfIntegers = json.getIntegerArray(INTEGER_ARRAY_KEY);
   ASSERT_EQ(numberOfIntegersInArray, returnedArrayOfIntegers.size());
 
   int returnedIntegerValue;
@@ -185,13 +174,13 @@ TEST_F(JsonTest, shouldGetArrayOfIntegersFromJson) {
 }
 
 TEST_F(JsonTest, shouldReturnEmptyArrayOfIntegersByDefaultWhenNoSuchKey) {
-  ASSERT_EQ(0, json -> getIntegerArray(INTEGER_ARRAY_KEY).size());
+  ASSERT_EQ(0, json.getIntegerArray(INTEGER_ARRAY_KEY).size());
 }
 
 TEST_F(JsonTest, shouldReturnIfKeyPresentInJson) {
   insertString();
-  EXPECT_TRUE(json -> contains(STRING_KEY));
-  EXPECT_FALSE(json -> contains(NOT_PRESENT_KEY));
+  EXPECT_TRUE(json.contains(STRING_KEY));
+  EXPECT_FALSE(json.contains(NOT_PRESENT_KEY));
 }
 
 TEST_F(JsonTest, shouldReturnAllKeysFromJson) {
@@ -199,7 +188,7 @@ TEST_F(JsonTest, shouldReturnAllKeysFromJson) {
   insertInteger();
   insertObject();
   const int EXPECTED_KEYS_COUNT = 3;
-  std::vector<std::string> keysFromJson = json -> getKeys();
+  std::vector<std::string> keysFromJson = json.getKeys();
   ASSERT_EQ(EXPECTED_KEYS_COUNT, keysFromJson.size());
   ASSERT_NO_FATAL_FAILURE(assertKeyFound(keysFromJson, STRING_KEY));
   ASSERT_NO_FATAL_FAILURE(assertKeyFound(keysFromJson, INTEGER_KEY));

--- a/test/MainWindowSampleTest.cpp
+++ b/test/MainWindowSampleTest.cpp
@@ -15,7 +15,7 @@ private slots:
 
 void MainWindowSampleTest::testLineEdit()
 {
-  MainWindowSample mainWindowSample(new Controller(new Model));
+  MainWindowSample mainWindowSample(new Controller(new Model()));
   QLineEdit* lineEdit = mainWindowSample.getLineEdit();
 
   QTest::keyClicks(lineEdit, "hello world");
@@ -24,7 +24,7 @@ void MainWindowSampleTest::testLineEdit()
 
 void MainWindowSampleTest::testNewGameButtonClick()
 {
-  MainWindowSample mainWindowSample(new Controller(new Model));
+  MainWindowSample mainWindowSample(new Controller(new Model()));
   QPushButton* newGameButton = mainWindowSample.getNewGameButton();
   QTextBrowser* textBrowser = mainWindowSample.getTextBrowser();
   QTest::mouseClick(newGameButton, Qt::LeftButton);

--- a/test/ModelTest.cpp
+++ b/test/ModelTest.cpp
@@ -8,58 +8,49 @@ using ::testing::Test;
 class ModelTest : public Test
 {
 protected:
-  ModelTest(void) {
-    model = new Model;
-  }
-  ~ModelTest(void) {
-    delete model;
-  }
-  Model* model;
-
-  virtual void SetUp(void) {}
-  virtual void TearDown(void) {}
+  Model model;
 };
 
 TEST_F(ModelTest, shouldInitializeGameStateWithPause) {
-  GameState currentState = model -> getGameState();
+  GameState currentState = model.getGameState();
   EXPECT_EQ(PAUSE, currentState);
 }
 
 TEST_F(ModelTest, shouldInitializeCurrentPlayerIdWithMinusOne) {
-  EXPECT_EQ(-1, model -> currentPlayerId);
+  EXPECT_EQ(-1, model.currentPlayerId);
 }
 
 TEST_F(ModelTest, shouldReturnNullForNoPlayers) {
-  Player* player = model->getCurrentPlayer();
+  Player* player = model.getCurrentPlayer();
   EXPECT_EQ(nullptr, player);
 }
 
 TEST_F(ModelTest, shouldGetPlayersQuantity) {
   Player* player = new Player(MOLOCH);
-  model -> players.push_back(player);
-  EXPECT_EQ(1, model -> getPlayersQuantity());
+  model.players.push_back(player);
+  EXPECT_EQ(1, model.getPlayersQuantity());
   delete player;
 }
 
 TEST_F(ModelTest, shouldInitializePlayerQuantityWithZero) {
-  int quantity = model -> getPlayersQuantity();
+  int quantity = model.getPlayersQuantity();
   EXPECT_EQ(0, quantity);
 }
 
 TEST_F(ModelTest, shouldAddPlayer) {
   Player* newPlayer = new Player(MOLOCH);
-  model -> addPlayer(newPlayer);
-  EXPECT_EQ(newPlayer, model -> getCurrentPlayer());
-  EXPECT_EQ(1, model -> getPlayersQuantity());
+  model.addPlayer(newPlayer);
+  EXPECT_EQ(newPlayer, model.getCurrentPlayer());
+  EXPECT_EQ(1, model.getPlayersQuantity());
   delete newPlayer;
 }
 
 TEST_F(ModelTest, shouldSetCurrentPlayerIdToZeroWhenAddingFirstPlayer) {
   Player* firstPlayer = new Player(MOLOCH);
   Player* secondPlayer = new Player(OUTPOST);
-  model -> addPlayer(firstPlayer);
-  model -> addPlayer(secondPlayer);
-  EXPECT_EQ(0, model -> currentPlayerId);
+  model.addPlayer(firstPlayer);
+  model.addPlayer(secondPlayer);
+  EXPECT_EQ(0, model.currentPlayerId);
   delete firstPlayer;
   delete secondPlayer;
 }
@@ -67,9 +58,9 @@ TEST_F(ModelTest, shouldSetCurrentPlayerIdToZeroWhenAddingFirstPlayer) {
 TEST_F(ModelTest, shouldGetPlayerByArmy) {
   Player* molochPlayer = new Player(MOLOCH);
   Player* outpostPlayer = new Player(OUTPOST);
-  model -> addPlayer(molochPlayer);
-  model -> addPlayer(outpostPlayer);
-  EXPECT_EQ(molochPlayer, model -> getPlayer(MOLOCH));
+  model.addPlayer(molochPlayer);
+  model.addPlayer(outpostPlayer);
+  EXPECT_EQ(molochPlayer, model.getPlayer(MOLOCH));
   delete molochPlayer;
   delete outpostPlayer;
 }
@@ -77,13 +68,13 @@ TEST_F(ModelTest, shouldGetPlayerByArmy) {
 TEST_F(ModelTest, shouldMoveToNextPlayer) {
   Player* firstPlayer = new Player(MOLOCH);
   Player* secondPlayer = new Player(OUTPOST);
-  model -> addPlayer(firstPlayer);
-  model -> addPlayer(secondPlayer);
-  EXPECT_EQ(firstPlayer, model -> getCurrentPlayer());
-  model -> moveToNextPlayer();
-  EXPECT_EQ(secondPlayer, model -> getCurrentPlayer());
-  model -> moveToNextPlayer();
-  EXPECT_EQ(firstPlayer, model -> getCurrentPlayer());
+  model.addPlayer(firstPlayer);
+  model.addPlayer(secondPlayer);
+  EXPECT_EQ(firstPlayer, model.getCurrentPlayer());
+  model.moveToNextPlayer();
+  EXPECT_EQ(secondPlayer, model.getCurrentPlayer());
+  model.moveToNextPlayer();
+  EXPECT_EQ(firstPlayer, model.getCurrentPlayer());
   delete secondPlayer;
   delete firstPlayer;
 }
@@ -91,23 +82,23 @@ TEST_F(ModelTest, shouldMoveToNextPlayer) {
 //FIXME: move most of this test to PlayerTest
 TEST_F(ModelTest, shouldDestroyToken) {
   Player* player = new Player(MOLOCH);
-  model -> addPlayer(player);
+  model.addPlayer(player);
   BoardToken* token = new BoardToken(MOLOCH, "token");
   Field* field = new Field;
   field -> setToken(token);
   token -> setField(field);
   player -> tokensOnBoard.push_back(token);
-  model -> killToken(token);
+  model.killToken(token);
   EXPECT_TRUE(player -> tokensOnBoard.empty());
-  EXPECT_EQ(nullptr, field -> getToken());
+  EXPECT_EQ(nullptr, field->getToken());
 }
 
 TEST_F(ModelTest, shouldResetGame) {
   Player* player = new Player(MOLOCH);
-  model -> addPlayer(player);
-  model -> setGameState(GAME);
-  model -> reset();
-  EXPECT_EQ(PAUSE, model -> getGameState());
-  EXPECT_EQ(0, model -> getPlayersQuantity());
-  EXPECT_EQ(nullptr, model -> getCurrentPlayer());
+  model.addPlayer(player);
+  model.setGameState(GAME);
+  model.reset();
+  EXPECT_EQ(PAUSE, model.getGameState());
+  EXPECT_EQ(0, model.getPlayersQuantity());
+  EXPECT_EQ(nullptr, model.getCurrentPlayer());
 }

--- a/test/ModuleTokenTest.cpp
+++ b/test/ModuleTokenTest.cpp
@@ -33,8 +33,6 @@ protected:
   ~ModuleTokenTest() {
     delete unit;
   }
-  void SetUp() {}
-  void TearDown() {}
 
   Attribute* initiative;
   Attributes* mainUnitAttributes;
@@ -48,12 +46,12 @@ protected:
 
 TEST_F(ModuleTokenTest, shouldNotAffectEnemiesOnDefault) {
   Upgrader* upgrader = new ChangeAttributeUpgrader(new ModuleToken(HEGEMONY, "Officer", mainModuleAttributes, activeEdges), MELEE, 1);
-  ASSERT_FALSE(upgrader  ->  isAffectingEnemies());
+  ASSERT_FALSE(upgrader->isAffectingEnemies());
 }
 
 TEST_F(ModuleTokenTest, shouldAffectEnemies) {
   Upgrader* upgrader = new ChangeAttributeUpgrader(new ModuleToken(HEGEMONY, "Officer", mainModuleAttributes, activeEdges), MELEE, 1, true);
-  ASSERT_TRUE(upgrader  ->  isAffectingEnemies());
+  ASSERT_TRUE(upgrader->isAffectingEnemies());
 }
 
 TEST_F(ModuleTokenTest, shouldAddBoardToken) {
@@ -61,7 +59,7 @@ TEST_F(ModuleTokenTest, shouldAddBoardToken) {
   EXPECT_TRUE(module -> boardTokens.empty());
   module -> addBoardToken(unit);
   EXPECT_EQ(1, module -> boardTokens.size());
-  EXPECT_EQ("UniversalSoldier", module -> boardTokens[0] -> getName());
+  EXPECT_EQ("UniversalSoldier", module->boardTokens[0]->getName());
   delete module;
 }
 
@@ -74,43 +72,43 @@ TEST_F(ModuleTokenTest, shouldRemoveBoardToken) {
   module -> addBoardToken(soldier);
   module -> addBoardToken(anotherSoldier);
   EXPECT_EQ(3, module -> boardTokens.size());
-  EXPECT_EQ("Soldier", module -> boardTokens[1] -> getName());
+  EXPECT_EQ("Soldier", module->boardTokens[1]->getName());
   module -> removeBoardToken(soldier);
   EXPECT_EQ(2, module -> boardTokens.size());
-  EXPECT_EQ("UniversalSoldier", module -> boardTokens[1] -> getName());
+  EXPECT_EQ("UniversalSoldier", module->boardTokens[1]->getName());
   module -> removeBoardToken(anotherSoldier);
   EXPECT_EQ(1, module -> boardTokens.size());
-  EXPECT_EQ("UniversalSoldier", module -> boardTokens[0] -> getName());
+  EXPECT_EQ("UniversalSoldier", module->boardTokens[0]->getName());
   EXPECT_EQ(unit, module -> boardTokens[0]);
   delete module;
 }
 
 TEST_F(ModuleTokenTest, shouldUpgradeBaseAttribute) {
-  int oldInitiativeValue = unit -> getAttribute(INITIATIVE) -> getValue();
+  int oldInitiativeValue = unit->getAttribute(INITIATIVE)->getValue();
   ASSERT_EQ(2, oldInitiativeValue);
   Module* ranger = new ChangeAttributeUpgrader(new ModuleToken(HEGEMONY, "Ranger", mainModuleAttributes, activeEdges), INITIATIVE, 1);
   ranger -> addBoardToken(unit);
-  int newInitiativeValue = unit -> getAttribute(INITIATIVE) -> getValue();
+  int newInitiativeValue = unit->getAttribute(INITIATIVE)->getValue();
   ASSERT_EQ(3, newInitiativeValue);
 }
 
 TEST_F(ModuleTokenTest, shouldDowngradeAttributeOnRemove) {
   Module* ranger = new ChangeAttributeUpgrader(new ModuleToken(HEGEMONY, "Ranger", mainModuleAttributes, activeEdges), INITIATIVE, 1);
   ranger -> addBoardToken(unit);
-  int attributeValue = unit -> getAttribute(INITIATIVE) -> getValue();
+  int attributeValue = unit->getAttribute(INITIATIVE)->getValue();
   EXPECT_EQ(3, attributeValue);
   ranger -> removeBoardToken(unit);
-  attributeValue = unit -> getAttribute(INITIATIVE) -> getValue();
+  attributeValue = unit->getAttribute(INITIATIVE)->getValue();
   EXPECT_EQ(2, attributeValue);
 }
 
 TEST_F(ModuleTokenTest, shouldUpgradeEdgeAttribute) {
   Module* officer = new ChangeAttributeUpgrader(new ModuleToken(HEGEMONY, "Officer", mainModuleAttributes, activeEdges), MELEE, 1);
   Attribute* melee = unit -> getEdgeAttributes(Side::NORTH) -> getAttribute(MELEE);
-  int oldMeleeValue = melee -> getValue();
+  int oldMeleeValue = melee->getValue();
   ASSERT_EQ(1, oldMeleeValue);
   officer -> addBoardToken(unit);
-  int newMeleeValue = melee -> getValue();
+  int newMeleeValue = melee->getValue();
   ASSERT_EQ(2, newMeleeValue);
 }
 
@@ -121,42 +119,42 @@ TEST_F(ModuleTokenTest, shouldAddAttribute) {
   transport -> addBoardToken(unit);
   unitAttribute = unit -> getAttribute(MOBILITY);
   ASSERT_NE((Attribute*) 0, unitAttribute);
-  int mobilityValue = unit -> getAttribute(MOBILITY) -> getValue();
+  int mobilityValue = unit->getAttribute(MOBILITY)->getValue();
   ASSERT_EQ(1, mobilityValue);
 }
 
 TEST_F(ModuleTokenTest, shouldDowngradeEnemyAttribute) {
   Attribute* initiative = unit -> getAttribute(INITIATIVE);
   ASSERT_NE((Attribute*) 0, initiative);
-  int oldInitiativeValue = initiative -> getValue();
+  int oldInitiativeValue = initiative->getValue();
   ASSERT_EQ(2, oldInitiativeValue);
   Module* saboteur = new ChangeAttributeUpgrader(new ModuleToken(OUTPOST, "Saboteur", mainModuleAttributes, activeEdges), INITIATIVE, -1);
   saboteur -> addBoardToken(unit);
-  int newInitiativeValue = unit -> getAttribute(INITIATIVE) -> getValue();
+  int newInitiativeValue = unit->getAttribute(INITIATIVE)->getValue();
   ASSERT_EQ(1, newInitiativeValue);
 }
 
 TEST_F(ModuleTokenTest, shouldCaptureEnemyModule) {
   Module* scoper = new ChangeArmyUpgrader(new ModuleToken(OUTPOST, "Scoper", mainModuleAttributes, activeEdges));
-  EXPECT_EQ(HEGEMONY, unit -> getArmy());
+  EXPECT_EQ(HEGEMONY, unit->getArmy());
   scoper -> addBoardToken(unit);
-  ASSERT_EQ(OUTPOST, unit -> getArmy());
+  ASSERT_EQ(OUTPOST, unit->getArmy());
   scoper -> removeBoardToken(unit);
-  EXPECT_EQ(HEGEMONY, unit -> getArmy());
+  EXPECT_EQ(HEGEMONY, unit->getArmy());
   UnitToken* anotherUnit = new UnitToken(MOLOCH, "Gauss cannon", mainUnitAttributes);
   anotherUnit -> setEdgeAttributes(Side::NORTH, northSideAttributes);
-  EXPECT_EQ(MOLOCH, anotherUnit -> getArmy());
+  EXPECT_EQ(MOLOCH, anotherUnit->getArmy());
   scoper -> addBoardToken(anotherUnit);
-  ASSERT_EQ(OUTPOST, anotherUnit -> getArmy());
+  ASSERT_EQ(OUTPOST, anotherUnit->getArmy());
 }
 
 TEST_F(ModuleTokenTest, shouldApplyTwoDifferentUpgradesFromOneModule) {
   Module* boss = new ChangeAttributeUpgrader(new ChangeAttributeUpgrader(new ModuleToken(HEGEMONY, "Boss", mainModuleAttributes, activeEdges), MELEE, 1), INITIATIVE, 2);
-  ASSERT_EQ(1, unit -> getEdgeAttributes(Side::NORTH) -> getAttribute(MELEE) -> getValue());
-  ASSERT_EQ(2, unit -> getAttribute(INITIATIVE) -> getValue());
+  ASSERT_EQ(1, unit->getEdgeAttributes(Side::NORTH)->getAttribute(MELEE)->getValue());
+  ASSERT_EQ(2, unit->getAttribute(INITIATIVE)->getValue());
 
   boss -> addBoardToken(unit);
 
-  ASSERT_EQ(2, unit -> getEdgeAttributes(Side::NORTH) -> getAttribute(MELEE) -> getValue());
-  ASSERT_EQ(4, unit -> getAttribute(INITIATIVE) -> getValue());
+  ASSERT_EQ(2, unit->getEdgeAttributes(Side::NORTH)->getAttribute(MELEE)->getValue());
+  ASSERT_EQ(4, unit->getAttribute(INITIATIVE)->getValue());
 }

--- a/test/PlayerTest.cpp
+++ b/test/PlayerTest.cpp
@@ -9,94 +9,69 @@ using ::testing::Test;
 class PlayerTest : public Test
 {
 protected:
-  PlayerTest(void) {
-  }
-  ~PlayerTest(void) {
-  }
-
-  virtual void SetUp(void) {
-    player = new Player(MOLOCH);
-  }
-
-  virtual void TearDown(void) {
-    delete player;
-  }
-
-  Player* player;
+  Player player {MOLOCH};
 };
 
 TEST_F(PlayerTest, shouldKillToken) {
-  BoardToken* token = new BoardToken(MOLOCH, "token");
-  player -> tokensOnBoard.push_back(token);
-  player -> killToken(token);
-  EXPECT_TRUE(player -> tokensOnBoard.empty());
-  ASSERT_FALSE(player -> usedTokens.empty());
-  EXPECT_EQ(token, player -> usedTokens[0]);
-  delete token;
-}
+  BoardToken token {MOLOCH, "token"};
+  player.tokensOnBoard.push_back(&token);
+  player.killToken(&token);
+  EXPECT_TRUE(player.tokensOnBoard.empty());
+  ASSERT_FALSE(player.usedTokens.empty());
+  EXPECT_EQ(&token, player.usedTokens[0]);
+};
 
 TEST_F(PlayerTest, shouldUseToken) {
-  Token* token = new Token(MOLOCH, "token");
-  player -> tokensOnHand.push_back(token);
-  player -> useToken(token);
-  EXPECT_TRUE(player -> tokensOnHand.empty());
-  ASSERT_FALSE(player -> usedTokens.empty());
-  EXPECT_EQ(token, player -> usedTokens[0]);
-  delete token;
-}
+  Token token {MOLOCH, "token"};
+  player.tokensOnHand.push_back(&token);
+  player.useToken(&token);
+  EXPECT_TRUE(player.tokensOnHand.empty());
+  ASSERT_FALSE(player.usedTokens.empty());
+  EXPECT_EQ(&token, player.usedTokens[0]);
+};
 
 TEST_F(PlayerTest, shouldPutTokenOnBoard) {
-  BoardToken* token = new BoardToken(MOLOCH, "token");
-  player -> tokensOnHand.push_back(token);
-  player -> putOnBoard(token);
-  EXPECT_TRUE(player -> tokensOnHand.empty());
-  ASSERT_FALSE(player -> tokensOnBoard.empty());
-  EXPECT_EQ(token, player -> tokensOnBoard[0]);
-  delete token;
-}
+  BoardToken token {MOLOCH, "token"};
+  player.tokensOnHand.push_back(&token);
+  player.putOnBoard(&token);
+  EXPECT_TRUE(player.tokensOnHand.empty());
+  ASSERT_FALSE(player.tokensOnBoard.empty());
+  EXPECT_EQ(&token, player.tokensOnBoard[0]);
+};
 
 TEST_F(PlayerTest, shouldDrawTokens) {
-  Token* token1 = new Token(MOLOCH, "token");
-  Token* token2 = new Token(MOLOCH, "token");
-  Token* token3 = new Token(MOLOCH, "token");
-  Token* token4 = new Token(MOLOCH, "token");
-  player -> hiddenTokens.push_back(token1);
-  player -> hiddenTokens.push_back(token2);
-  player -> hiddenTokens.push_back(token3);
-  player -> hiddenTokens.push_back(token4);
+  Token token1 {MOLOCH, "token"};
+  Token token2 {MOLOCH, "token"};
+  Token token3 {MOLOCH, "token"};
+  Token token4 {MOLOCH, "token"};
+  player.hiddenTokens.push_back(&token1);
+  player.hiddenTokens.push_back(&token2);
+  player.hiddenTokens.push_back(&token3);
+  player.hiddenTokens.push_back(&token4);
 
-  player -> drawTokens(1);
-  ASSERT_FALSE(player -> tokensOnHand.empty());
-  EXPECT_EQ(token4, player -> tokensOnHand.back());
-  EXPECT_EQ(3, player -> hiddenTokens.size());
+  player.drawTokens(1);
+  ASSERT_FALSE(player.tokensOnHand.empty());
+  EXPECT_EQ(&token4, player.tokensOnHand.back());
+  EXPECT_EQ(3, player.hiddenTokens.size());
 
-  player -> drawTokens();
-  EXPECT_TRUE(player -> hiddenTokens.empty());
-  ASSERT_FALSE(player -> tokensOnHand.empty());
-  EXPECT_EQ(token1, player -> tokensOnHand.back());
-  EXPECT_EQ(4, player -> tokensOnHand.size());
-
-  delete token1;
-  delete token2;
-  delete token3;
-  delete token4;
-}
+  player.drawTokens();
+  EXPECT_TRUE(player.hiddenTokens.empty());
+  ASSERT_FALSE(player.tokensOnHand.empty());
+  EXPECT_EQ(&token1, player.tokensOnHand.back());
+  EXPECT_EQ(4, player.tokensOnHand.size());
+};
 
 TEST_F(PlayerTest, shouldGetTokenFromHand) {
-  Token* token1 = new Token(MOLOCH, "token");
-  Token* token2 = new Token(MOLOCH, "token");
-  Token* token3 = new Token(MOLOCH, "token");
-  player -> tokensOnHand.push_back(token1);
-  player -> tokensOnHand.push_back(token2);
-  player -> tokensOnHand.push_back(token3);
-  ASSERT_EQ(token1, player -> getTokenOnHand(0));
-  ASSERT_EQ(token2, player -> getTokenOnHand(1));
-  ASSERT_EQ(token3, player -> getTokenOnHand(2));
-
-  delete token1;
-  delete token2;
-  delete token3;
-}
+  Token token1 {MOLOCH, "token"};
+  Token token2 {MOLOCH, "token"};
+  Token token3 {MOLOCH, "token"};
+  player.tokensOnHand.push_back(&token1);
+  player.tokensOnHand.push_back(&token2);
+  player.tokensOnHand.push_back(&token3);
+  ASSERT_EQ(&token1, player.getTokenOnHand(0));
+  ASSERT_EQ(&token2, player.getTokenOnHand(1));
+  ASSERT_EQ(&token3, player.getTokenOnHand(2));
+};
 
 //TODO: implement
 TEST_F(PlayerTest, DISABLED_shouldThrowExceptionWhenGettingNonExistingToken) {

--- a/test/StringToEnumTranslatorTest.cpp
+++ b/test/StringToEnumTranslatorTest.cpp
@@ -6,13 +6,6 @@ using ::testing::Test;
 #include "../src/setup/StringToEnumTranslator.hpp"
 
 class StringToEnumTranslatorTest : public Test {
-protected:
-  StringToEnumTranslatorTest() {}
-
-  virtual ~StringToEnumTranslatorTest() {}
-
-  virtual void SetUp() {}
-  virtual void TearDown() {}
 };
 
 //TODO: read about value parametrized tests and maybe use them here

--- a/test/TokenTest.cpp
+++ b/test/TokenTest.cpp
@@ -13,78 +13,59 @@ const int ATTRIBUTE_VALUE = 4;
 class AttributeTest : public Test
 {
 protected:
-  AttributeTest() {
-    attribute = new Attribute("initiative", ATTRIBUTE_VALUE);
-  }
-  ~AttributeTest() {
-    delete attribute;
-  }
-
-  Attribute* attribute;
-
-  virtual void SetUp() {}
-  virtual void TearDown() {}
+  Attribute attribute {"initiative", ATTRIBUTE_VALUE};
 };
 
 TEST_F(AttributeTest, testGetAttributeValues) {
-  ASSERT_EQ("initiative", attribute -> getName());
-  ASSERT_EQ(ATTRIBUTE_VALUE, attribute -> getValue());
+  ASSERT_EQ("initiative", attribute.getName());
+  ASSERT_EQ(ATTRIBUTE_VALUE, attribute.getValue());
 }
 
 TEST_F(AttributeTest, testUpgradeAttribute) {
-  attribute -> upgradeBy();
+  attribute.upgradeBy();
   int upgradedValue = ATTRIBUTE_VALUE + 1;
-  ASSERT_EQ(upgradedValue, attribute -> getValue());
-  attribute -> upgradeBy(2);
+  ASSERT_EQ(upgradedValue, attribute.getValue());
+  attribute.upgradeBy(2);
   upgradedValue += 2;
-  ASSERT_EQ(upgradedValue, attribute -> getValue());
-  attribute -> upgradeTo(ATTRIBUTE_VALUE);
-  ASSERT_EQ(ATTRIBUTE_VALUE, attribute -> getValue());
+  ASSERT_EQ(upgradedValue, attribute.getValue());
+  attribute.upgradeTo(ATTRIBUTE_VALUE);
+  ASSERT_EQ(ATTRIBUTE_VALUE, attribute.getValue());
 }
 
 TEST_F(AttributeTest, testDowngradeAttribute) {
-  attribute -> downgradeBy();
+  attribute.downgradeBy();
   int downgradedValue = ATTRIBUTE_VALUE - 1;
-  ASSERT_EQ(downgradedValue, attribute -> getValue());
-  attribute -> downgradeBy(2);
+  ASSERT_EQ(downgradedValue, attribute.getValue());
+  attribute.downgradeBy(2);
   downgradedValue -= 2;
-  ASSERT_EQ(downgradedValue, attribute -> getValue());
+  ASSERT_EQ(downgradedValue, attribute.getValue());
   downgradedValue = ATTRIBUTE_VALUE - 1;
-  attribute -> downgradeTo(ATTRIBUTE_VALUE-1);
-  ASSERT_EQ(downgradedValue, attribute -> getValue());
+  attribute.downgradeTo(ATTRIBUTE_VALUE-1);
+  ASSERT_EQ(downgradedValue, attribute.getValue());
 }
 
 TEST_F(AttributeTest, testResetAttributeValue) {
-  attribute -> upgradeTo(ATTRIBUTE_VALUE + 3);
+  attribute.upgradeTo(ATTRIBUTE_VALUE + 3);
   int value = ATTRIBUTE_VALUE + 3;
-  ASSERT_EQ(value, attribute -> getValue());
-  attribute -> resetValue();
+  ASSERT_EQ(value, attribute.getValue());
+  attribute.resetValue();
   value = ATTRIBUTE_VALUE;
-  ASSERT_EQ(value, attribute -> getValue());
-  attribute -> downgradeTo(ATTRIBUTE_VALUE-1);
+  ASSERT_EQ(value, attribute.getValue());
+  attribute.downgradeTo(ATTRIBUTE_VALUE-1);
   value = ATTRIBUTE_VALUE - 1;
-  ASSERT_EQ(value, attribute -> getValue());
-  attribute -> resetValue();
+  ASSERT_EQ(value, attribute.getValue());
+  attribute.resetValue();
   value = ATTRIBUTE_VALUE;
-  ASSERT_EQ(value, attribute -> getValue());
+  ASSERT_EQ(value, attribute.getValue());
 }
 
-class AttributesTest : public Test
-{
-protected:
-  AttributesTest() {
-  }
-  ~AttributesTest() {
-  }
-
-  virtual void SetUp() {}
-  virtual void TearDown() {}
+class AttributesTest : public Test {
 };
 
 TEST_F(AttributesTest, shouldCreateAttributesObjectWithNoAttributes) {
   Attributes* attributes = new Attributes();
   ASSERT_NE(nullptr, attributes);
-  ASSERT_TRUE(attributes -> empty());
+  ASSERT_TRUE(attributes->empty());
 }
 
 TEST_F(AttributesTest, shouldAddAttribute) {

--- a/test/UnitTokenTest.cpp
+++ b/test/UnitTokenTest.cpp
@@ -18,9 +18,6 @@ protected:
     unit = new UnitToken(HEGEMONY, "UniversalSoldier", baseUnitAttributes);
     unit -> setEdgeAttributes(Side::NORTH, northSideAttributes);
   }
-  ~UnitTokenTest() {}
-  void SetUp() {}
-  void TearDown() {}
 
   UnitToken* unit;
   Attributes* baseUnitAttributes;
@@ -32,5 +29,5 @@ TEST_F(UnitTokenTest, testGetSideAttributes) {
   Attribute* melee = northSideAttributes -> getAttribute(MELEE);
   ASSERT_EQ(northSideAttributes, attributes);
   ASSERT_EQ(melee, attributes -> getAttribute(MELEE));
-  ASSERT_EQ(melee -> getValue(), attributes -> getAttribute(MELEE) -> getValue());
+  ASSERT_EQ(melee->getValue(), attributes->getAttribute(MELEE)->getValue());
 }


### PR DESCRIPTION
Declaring method with no parameters using void keyword is
redundant. Defining empty constructors, destructors and
empty methods in googletest fixture classes is also redundant.
This change removes most of such occurrences.

Instantiating objects on the free store when there are no reasons
to do this should be also avoided, so this change removes some
of such instantiations also.
